### PR TITLE
Avoid CORS errors

### DIFF
--- a/logstash/pipeline/logstash.conf
+++ b/logstash/pipeline/logstash.conf
@@ -2,7 +2,13 @@ input {
 	tcp {
 		port => 5000
 	}
-  http { }
+        http { 
+        	response_headers => {
+        		"Access-Control-Allow-Origin" => "*"
+        		"Content-Type" => "text/plain"
+        		"Access-Control-Allow-Headers" => "Origin, X-Requested-With, Content-Type, Accept"
+        	}
+	}
 }
 
 ## Add your filters / logstash plugins configuration here


### PR DESCRIPTION
Add HTTP headers to the response just to allow clients to send logs without CORS problems.